### PR TITLE
add initial module type definition for typescript integration

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to Auth module will be documented in this file.
 
+## [1.1.8] - 09-11-2020
+### Added
+- Add index.d.ts for TS support
+- Add "main", "files" and "types" to package.json to reduce package download size via npm install on consumers node_modules
+
 ## [1.1.7] - 15-10-2020
 ### Added
 - Attach permissions to group

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,95 @@
+
+declare namespace AuthV1 {
+  type DomainHostString = string;
+
+  export type LoginParams = {
+    name: string;
+    secret: string;
+    datasetId: string | number;
+    audience?: string[];
+  }
+
+  export interface AuthDetails {
+    identity_name: string;
+    secret: string;
+    dataset_id: string | number;
+    audience?: string[];
+  }
+
+  export interface AuthConnection {
+    domainName: DomainHostString;
+    stack_id: string;
+  }
+
+  export type ILoginToken = {
+    token: string;
+    checksum: string;
+  }
+
+  export type SubjectObject = {
+    actor: string;
+    stack_id: string;
+    dataset_id: string;
+    principal_id: string;
+    identity_id: string;
+  }
+
+  interface authConfig extends AuthDetails {
+    set(authConfig: AuthDetails): void;
+    get(): AuthDetails;
+  }
+
+  interface cacheConfig {
+    enableCaching: boolean;
+    set(config: { enableCaching: boolean }): void;
+    get(): { enableCaching: boolean }
+  }
+
+
+  interface serverConfig extends AuthConnection {
+    set(config: AuthConnection): void;
+    get(): AuthConnection;
+
+  }
+  export type Config = {
+    auth: authConfig;
+    cache: cacheConfig;
+    server: serverConfig
+  }
+
+  export abstract class V1Base {
+    internalAuth: boolean;
+    baseURL: string;
+    token: null | string;
+    loginAttempts: number;
+    requestID: null | string;
+    errorMessage: null | any;
+    errorCode: null | string;
+  }
+}
+
+declare module "@volcanic-uk/auth-module/v1" {
+  export class Identity extends AuthV1.V1Base {
+    login(opts: AuthV1.LoginParams): Promise<AuthV1.ILoginToken>;
+  }
+  export class Token extends AuthV1.V1Base {
+    validate(token: string): Promise<boolean>
+    isSingleUser(token: string): Promise<boolean>
+    remoteValidation(): Promise<boolean>
+    parseSubject(): AuthV1.SubjectObject | null
+  }
+
+  export const Config: AuthV1.Config
+
+  export class Principal extends AuthV1.V1Base { }
+  export class Key extends AuthV1.V1Base { }
+  export class Permission extends AuthV1.V1Base { }
+  export class Subject extends AuthV1.V1Base { }
+  export class Service extends AuthV1.V1Base { }
+  export class Group extends AuthV1.V1Base { }
+  export class Roles extends AuthV1.V1Base { }
+  export class Privilege extends AuthV1.V1Base { }
+  export class Authorization extends AuthV1.V1Base { }
+  export class AuthenticationMiddleware extends AuthV1.V1Base { }
+  export class AuthorizationMiddleware extends AuthV1.V1Base { }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@volcanic-uk/auth-module",
-  "version": "1.1.5",
+  "version": "1.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,15 @@
   "name": "@volcanic-uk/auth-module",
   "version": "1.1.7",
   "description": "a node module meant to authorize communication to various volcanic services",
-  "main": "index.js",
+  "main": "v1/index.js",
+  "types": "index.d.ts",
+  "files": [
+    "src/*",
+    "config/*",
+    "v1/*",
+    "config/*",
+    "index.d.ts"
+  ],
   "scripts": {
     "test": "mocha \"test/**/*.test.js\" --timeout 10000  --exit",
     "lint": "eslint ."


### PR DESCRIPTION

This PR will help document your methods and allows any Typescript consumer to use the module without ignoring TS features and it will immediately allow the user to validate the expected input without any tests, running environments, etc 

Currently the coverage is targeted at:
- Login workflow
- Config workflow 
- Tokens
- Named exports

Without this PR the TS engine kinda blows up.

the additions to the `package.json` file will ensure that the npm installer will only install needed files and it would point automatically to the main module entry and typing definition.

For more details https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html